### PR TITLE
Use copy-tree for all types of deep copy of sequence.

### DIFF
--- a/cl-mop.lisp
+++ b/cl-mop.lisp
@@ -71,8 +71,8 @@ It merely returns its results."
     copy))
 
 (defmethod deep-copy ((object sequence))
-  "A deep copy of a general sequence is merely (copy-seq sequence)."
-  (copy-seq object))
+  "A deep copy of a general sequence is (copy-tree sequence)."
+  (copy-tree object))
 
 (defmethod deep-copy ((object list))
   "A deep copy of a list is (copy-tree list)"

--- a/cl-mop.lisp
+++ b/cl-mop.lisp
@@ -74,10 +74,6 @@ It merely returns its results."
   "A deep copy of a general sequence is (copy-tree sequence)."
   (copy-tree object))
 
-(defmethod deep-copy ((object list))
-  "A deep copy of a list is (copy-tree list)"
-  (copy-tree object))
-
 (defmethod deep-copy ((object structure-object))
   "A deep copy of a structure-object is (copy-structure object)."
   (copy-structure object))


### PR DESCRIPTION
For general sequence sequences, copy-seq is sufficient. If it is created by make-array with parameters such as :adjustable and :fill-pointer, copy-seq alone is not enough. In this case, copy-tree must be used.

CL-USER> (describe (copy-tree (make-array 10 :adjustable t :fill-pointer 9)))
#(0 0 0 0 0 0 0 0 0)
  [vector]

Element-type: T
Fill-pointer: 9
Size: 10
Adjustable: yes
Displaced: no
Storage vector: #<(SIMPLE-VECTOR 10) {120871214F}>

CL-USER> (describe (copy-seq (make-array 10 :adjustable t :fill-pointer 9)))
#(0 0 0 0 0 0 0 0 0)
  [simple-vector]

Element-type: T
Length: 9
